### PR TITLE
setting undo row removal for sales to be disabled on default

### DIFF
--- a/wsgi/static/frontend/home.html
+++ b/wsgi/static/frontend/home.html
@@ -452,7 +452,7 @@ March 2015</p>
                     </table>
                      <button type="button" class="btn btn-default btn-xs" onclick="saleRows()">Add  <i class="fa fa-plus"></i></button>
                      <input type="text" id="addSales" value="1" size="2"> <span>more rows &nbsp; </span>
-                     <button type="button" id = "undo-sales" class="btn btn-default btn-xs" onclick="undoRowRemoval('sales')">Undo Row Removal</button>
+                     <button type="button" id = "undo-sales" class="btn btn-default btn-xs" onclick="undoRowRemoval('sales')" disabled>Undo Row Removal</button>
                 </div>
                 <div style="padding-top:10px">
                     <p>You can <button href="#!" class="btn btn-default" onclick="convertToCSV()">Convert to CSV</button>


### PR DESCRIPTION
The undo row removal button was not set to disabled as default
